### PR TITLE
feat: implement rate limiting middleware

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.5.0",
         "drizzle-orm": "^0.44.2",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "joi": "^18.0.0"
       },
       "devDependencies": {
@@ -1583,6 +1584,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1813,6 +1832,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.5.0",
     "drizzle-orm": "^0.44.2",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "joi": "^18.0.0"
   },
   "devDependencies": {

--- a/backend/src/middleware/rateLimit.js
+++ b/backend/src/middleware/rateLimit.js
@@ -1,0 +1,39 @@
+import rateLimit from "express-rate-limit";
+
+const createRateLimiter = (windowMs, max, message) => {
+  return rateLimit({
+    windowMs,
+    max,
+    message: {
+      success: false,
+      error: message,
+      timestamp: new Date().toISOString(),
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+};
+
+export const generalLimiter = createRateLimiter(
+  15 * 60 * 1000,
+  100,
+  "Too many requests from this IP, please try again later."
+);
+
+export const authLimiter = createRateLimiter(
+  15 * 60 * 1000,
+  5,
+  "Too many authentication attempts, please try again later."
+);
+
+export const favoritesLimiter = createRateLimiter(
+  15 * 60 * 1000,
+  50,
+  "Too many favorites requests, please try again later."
+);
+
+export const strictLimiter = createRateLimiter(
+  15 * 60 * 1000,
+  10,
+  "Too many requests, please try again later."
+); 

--- a/backend/src/routes/favorite.route.js
+++ b/backend/src/routes/favorite.route.js
@@ -5,15 +5,19 @@ import {
   validateUserId,
   validateFavoriteParams,
 } from "../middleware/validation.js";
+import { favoritesLimiter } from "../middleware/rateLimit.js";
 
 const router = Router();
 
-router.post("/", validateFavoriteData, FavoriteController.addFavorite);
+router.post("/", favoritesLimiter, validateFavoriteData, FavoriteController.addFavorite);
+
 router.delete(
   "/:userId/:recipeId",
+  favoritesLimiter,
   validateFavoriteParams,
   FavoriteController.removeFavorite
 );
-router.get("/:userId", validateUserId, FavoriteController.getFavorites);
+
+router.get("/:userId", favoritesLimiter, validateUserId, FavoriteController.getFavorites);
 
 export { router as favoriteRoutes };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,12 +3,15 @@ import cors from "cors";
 import { ENV } from "./config/env.js";
 import router from "./routes/index.js";
 import { errorHandler, notFoundHandler } from "./middleware/errorHandler.js";
+import { generalLimiter } from "./middleware/rateLimit.js";
 
 const app = express();
 const PORT = ENV.PORT || 5001;
 
 app.use(cors());
 app.use(express.json());
+
+app.use(generalLimiter);
 
 app.use("/api", router);
 


### PR DESCRIPTION
- Add express-rate-limit dependency
- Create rate limiting middleware with different configurations
- Implement generalLimiter for all routes (100 requests per 15 minutes)
- Implement favoritesLimiter for favorites routes (50 requests per 15 minutes)
- Add authLimiter for authentication routes (5 requests per 15 minutes)
- Add strictLimiter for sensitive routes (10 requests per 15 minutes)
- Apply rate limiting to server and favorite routes
- Add custom error messages for rate limit exceeded